### PR TITLE
Fix All Race Conditions Detected by Tests

### DIFF
--- a/timedmap.go
+++ b/timedmap.go
@@ -122,6 +122,8 @@ func (tm *TimedMap) GetValue(key interface{}) interface{} {
 	if v == nil {
 		return nil
 	}
+	tm.mtx.RLock()
+	defer tm.mtx.RUnlock()
 	return v.value
 }
 

--- a/timedmap_test.go
+++ b/timedmap_test.go
@@ -2,6 +2,7 @@ package timedmap
 
 import (
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -19,7 +20,7 @@ func TestNew(t *testing.T) {
 	assert.NotNil(t, tm)
 	assert.EqualValues(t, 0, len(tm.container))
 	time.Sleep(10 * time.Millisecond)
-	assert.True(t, tm.cleanerRunning.Load())
+	assert.True(t, atomic.LoadUint32(tm.cleanerRunning) != 0)
 }
 
 func TestFromMap(t *testing.T) {
@@ -246,7 +247,7 @@ func TestStopCleaner(t *testing.T) {
 	time.Sleep(10 * time.Millisecond)
 	tm.StopCleaner()
 	time.Sleep(10 * time.Millisecond)
-	assert.False(t, tm.cleanerRunning.Load())
+	assert.False(t, atomic.LoadUint32(tm.cleanerRunning) != 0)
 
 	assert.NotPanics(t, func() {
 		tm.StopCleaner()
@@ -259,7 +260,7 @@ func TestStartCleanerInternal(t *testing.T) {
 		tm := New(0)
 		time.Sleep(10 * time.Millisecond)
 
-		assert.False(t, tm.cleanerRunning.Load())
+		assert.False(t, atomic.LoadUint32(tm.cleanerRunning) != 0)
 
 		// Ensure cleanup timer is not running
 		tm.set(1, 0, 1, 0)
@@ -268,7 +269,7 @@ func TestStartCleanerInternal(t *testing.T) {
 
 		tm.StartCleanerInternal(dCleanupTick)
 		time.Sleep(10 * time.Millisecond)
-		assert.True(t, tm.cleanerRunning.Load())
+		assert.True(t, atomic.LoadUint32(tm.cleanerRunning) != 0)
 
 		// Ensure cleanup timer is running
 		tm.set(1, 0, 1, 0)
@@ -294,7 +295,7 @@ func TestStartCleanerExternal(t *testing.T) {
 		tm := New(0)
 		time.Sleep(10 * time.Millisecond)
 
-		assert.False(t, tm.cleanerRunning.Load())
+		assert.False(t, atomic.LoadUint32(tm.cleanerRunning) != 0)
 
 		// Ensure cleanup timer is not running
 		tm.set(1, 0, 1, 0)
@@ -305,7 +306,7 @@ func TestStartCleanerExternal(t *testing.T) {
 
 		tm.StartCleanerExternal(c)
 		time.Sleep(10 * time.Millisecond)
-		assert.True(t, tm.cleanerRunning.Load())
+		assert.True(t, atomic.LoadUint32(tm.cleanerRunning) != 0)
 
 		// Ensure cleanup is controlled by c
 		tm.set(1, 0, 1, 0)
@@ -323,7 +324,7 @@ func TestStartCleanerExternal(t *testing.T) {
 		tm := New(dCleanupTick)
 		time.Sleep(10 * time.Millisecond)
 
-		assert.True(t, tm.cleanerRunning.Load())
+		assert.True(t, atomic.LoadUint32(tm.cleanerRunning) != 0)
 		assert.NotNil(t, tm.cleanerTicker)
 
 		c := make(chan time.Time)

--- a/timedmap_test.go
+++ b/timedmap_test.go
@@ -19,7 +19,7 @@ func TestNew(t *testing.T) {
 	assert.NotNil(t, tm)
 	assert.EqualValues(t, 0, len(tm.container))
 	time.Sleep(10 * time.Millisecond)
-	assert.True(t, tm.cleanerRunning)
+	assert.True(t, tm.cleanerRunning.Load())
 }
 
 func TestFromMap(t *testing.T) {
@@ -246,7 +246,7 @@ func TestStopCleaner(t *testing.T) {
 	time.Sleep(10 * time.Millisecond)
 	tm.StopCleaner()
 	time.Sleep(10 * time.Millisecond)
-	assert.False(t, tm.cleanerRunning)
+	assert.False(t, tm.cleanerRunning.Load())
 
 	assert.NotPanics(t, func() {
 		tm.StopCleaner()
@@ -259,7 +259,7 @@ func TestStartCleanerInternal(t *testing.T) {
 		tm := New(0)
 		time.Sleep(10 * time.Millisecond)
 
-		assert.False(t, tm.cleanerRunning)
+		assert.False(t, tm.cleanerRunning.Load())
 
 		// Ensure cleanup timer is not running
 		tm.set(1, 0, 1, 0)
@@ -268,7 +268,7 @@ func TestStartCleanerInternal(t *testing.T) {
 
 		tm.StartCleanerInternal(dCleanupTick)
 		time.Sleep(10 * time.Millisecond)
-		assert.True(t, tm.cleanerRunning)
+		assert.True(t, tm.cleanerRunning.Load())
 
 		// Ensure cleanup timer is running
 		tm.set(1, 0, 1, 0)
@@ -294,7 +294,7 @@ func TestStartCleanerExternal(t *testing.T) {
 		tm := New(0)
 		time.Sleep(10 * time.Millisecond)
 
-		assert.False(t, tm.cleanerRunning)
+		assert.False(t, tm.cleanerRunning.Load())
 
 		// Ensure cleanup timer is not running
 		tm.set(1, 0, 1, 0)
@@ -305,7 +305,7 @@ func TestStartCleanerExternal(t *testing.T) {
 
 		tm.StartCleanerExternal(c)
 		time.Sleep(10 * time.Millisecond)
-		assert.True(t, tm.cleanerRunning)
+		assert.True(t, tm.cleanerRunning.Load())
 
 		// Ensure cleanup is controlled by c
 		tm.set(1, 0, 1, 0)
@@ -323,7 +323,7 @@ func TestStartCleanerExternal(t *testing.T) {
 		tm := New(dCleanupTick)
 		time.Sleep(10 * time.Millisecond)
 
-		assert.True(t, tm.cleanerRunning)
+		assert.True(t, tm.cleanerRunning.Load())
 		assert.NotNil(t, tm.cleanerTicker)
 
 		c := make(chan time.Time)


### PR DESCRIPTION
Fixes #7 and many other data races detected by `go test -race -v .`.

The race conditions are caused by accessing `expires` field of `element` from multiple goroutines. To fix this, acquire locks wherever missing. Another race condition is caused by `cleanupRunning` boolean being accessed from multiple goroutines in `TimedMap`. To fix this, made it `atomic.Bool`. There is very slight performance reduction obviously due to increase in locks, but it shouldn't cause much difference.

Here are benchmarks:

System Configuration:

**OS:** Garuda Linux with KDE Plasma
**Kernel:** Linux Zen 6.6.2
**RAM:** 16 GB
**Swap:** 48 GB
**CPU:** AMD Ryzen 9 5900HX (8 cores/16 threads)
**Frequency Driver:** amd-pstate-epp
**CPU Governor:** Performance


**Benchmark on master branch before fix:**

```
#> go test -bench=. -run=^$ . -benchmem -memprofile memprofile.out -cpuprofile cpuprofile.out -count 3
goos: linux
goarch: amd64
pkg: github.com/zekroTJA/timedmap
cpu: AMD Ryzen 9 5900HX with Radeon Graphics        
BenchmarkSetValues-16                    2422465               561.4 ns/op           210 B/op          3 allocs/op
BenchmarkSetValues-16                    2203539               544.4 ns/op           223 B/op          3 allocs/op
BenchmarkSetValues-16                    2503924               524.0 ns/op           206 B/op          3 allocs/op
BenchmarkSetGetValues-16                 2223829               610.5 ns/op           222 B/op          3 allocs/op
BenchmarkSetGetValues-16                 2273308               613.9 ns/op           219 B/op          3 allocs/op
BenchmarkSetGetValues-16                 2249521               617.6 ns/op           220 B/op          3 allocs/op
BenchmarkSetGetRemoveValues-16           5490228               218.2 ns/op            16 B/op          1 allocs/op
BenchmarkSetGetRemoveValues-16           5499961               216.9 ns/op            16 B/op          1 allocs/op
BenchmarkSetGetRemoveValues-16           5254581               217.2 ns/op            15 B/op          1 allocs/op
BenchmarkSetGetSameKey-16                8447968               140.9 ns/op             8 B/op          0 allocs/op
BenchmarkSetGetSameKey-16                8322252               141.8 ns/op             8 B/op          0 allocs/op
BenchmarkSetGetSameKey-16                8402802               141.6 ns/op             8 B/op          0 allocs/op
PASS
ok      github.com/zekroTJA/timedmap    41.890s
```

**Benchmark after fix:**

```
 #>  go test -bench=. -run=^$ . -benchmem -memprofile memprofile.out -cpuprofile cpuprofile.out -count 3
goos: linux
goarch: amd64
pkg: github.com/zekroTJA/timedmap
cpu: AMD Ryzen 9 5900HX with Radeon Graphics        
BenchmarkSetValues-16                    2139951               561.7 ns/op           227 B/op          3 allocs/op
BenchmarkSetValues-16                    2398006               535.0 ns/op           212 B/op          3 allocs/op
BenchmarkSetValues-16                    2589860               509.7 ns/op           202 B/op          3 allocs/op
BenchmarkSetGetValues-16                 2168884               629.1 ns/op           226 B/op          3 allocs/op
BenchmarkSetGetValues-16                 2196122               635.6 ns/op           224 B/op          3 allocs/op
BenchmarkSetGetValues-16                 2251090               623.2 ns/op           220 B/op          3 allocs/op
BenchmarkSetGetRemoveValues-16           5275246               226.6 ns/op            16 B/op          1 allocs/op
BenchmarkSetGetRemoveValues-16           5324313               224.8 ns/op            16 B/op          1 allocs/op
BenchmarkSetGetRemoveValues-16           5309869               224.7 ns/op            15 B/op          1 allocs/op
BenchmarkSetGetSameKey-16                7765312               152.2 ns/op             8 B/op          0 allocs/op
BenchmarkSetGetSameKey-16                7890106               151.2 ns/op             8 B/op          0 allocs/op
BenchmarkSetGetSameKey-16                7882216               153.1 ns/op             8 B/op          0 allocs/op
PASS
ok      github.com/zekroTJA/timedmap    41.985s
```

NOTE: I ran benchmarks on both cases 10+ times, and everytime the difference was near 90ms-1s, which can be caused by slight fluctuations. Overall it seems that this fix shouldn't cause any performance issues. Looking forward for review :)
